### PR TITLE
Harden authority contracts and add coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ DELPHI_DB_PATH=delphi.db
 # Web UI agent identity
 DELPHI_WEB_UI_AGENT_ID=web-ui
 DELPHI_WEB_UI_ROLES=orchestrator
+DELPHI_WEB_UI_PASSWORD=change-me

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Replaces manual copy-paste routing in a Delphi-method workflow where multiple in
 - **SQLite** (WAL mode) for message and agent state
 - **Message lifecycle:** `PENDING -> APPROVED/REJECTED -> ACKED`
 - **Role-based access:** orchestrator role required for approve/reject/broadcast
+- **Web UI auth:** HTTP Basic auth required for `/web/` using `web-ui` and `DELPHI_WEB_UI_PASSWORD`
 
 ## Configuration
 
@@ -24,6 +25,7 @@ Infrastructure config lives in `.env` (copy from `.env.example`):
 DELPHI_HOST=0.0.0.0
 DELPHI_PORT=8420
 DELPHI_DB_PATH=delphi.db
+DELPHI_WEB_UI_PASSWORD=change-me
 ```
 
 Agent registry lives in `config/agents.json` (gitignored, copy from example):

--- a/src/delphi_broker/config.py
+++ b/src/delphi_broker/config.py
@@ -47,11 +47,23 @@ DB_PATH: Path = (
 
 WEB_UI_AGENT_ID: str = os.environ.get("DELPHI_WEB_UI_AGENT_ID", "web-ui")
 WEB_UI_ROLES: str = os.environ.get("DELPHI_WEB_UI_ROLES", "orchestrator")
+WEB_UI_PASSWORD: str = os.environ.get("DELPHI_WEB_UI_PASSWORD", "").strip()
+
+if not WEB_UI_PASSWORD:
+    raise ValueError(
+        "Missing DELPHI_WEB_UI_PASSWORD in environment/.env. "
+        "The web approval surface requires explicit application-layer credentials."
+    )
 
 # ---------------------------------------------------------------------------
 # Agent registry (from config/agents.json)
 # ---------------------------------------------------------------------------
-_agents_file = _PROJECT_ROOT / "config" / "agents.json"
+_agents_path_raw = os.environ.get("DELPHI_AGENTS_PATH", "config/agents.json")
+_agents_file = (
+    Path(_agents_path_raw)
+    if Path(_agents_path_raw).is_absolute()
+    else _PROJECT_ROOT / _agents_path_raw
+)
 if not _agents_file.exists():
     raise FileNotFoundError(
         f"Agent registry not found: {_agents_file}. "
@@ -68,6 +80,6 @@ for _agent in SEED_AGENTS:
     if not _secret or _secret.startswith("GENERATE_WITH"):
         raise ValueError(
             f"Agent '{_agent['agent_id']}' has no valid secret in {_agents_file}. "
-            "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            'Generate one with: python -c "import secrets; print(secrets.token_hex(32))"'
         )
     AGENT_SECRETS[_agent["agent_id"]] = _secret

--- a/src/delphi_broker/database.py
+++ b/src/delphi_broker/database.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional
 
-from .config import AGENT_SECRETS, DB_PATH, SEED_AGENTS, WEB_UI_AGENT_ID, WEB_UI_ROLES
+from .config import DB_PATH, SEED_AGENTS, WEB_UI_AGENT_ID, WEB_UI_ROLES
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS agents (
@@ -139,6 +139,20 @@ def _apply_migrations(conn: sqlite3.Connection) -> None:
 # HMAC signing
 # ---------------------------------------------------------------------------
 
+
+def canonical_metadata_json(metadata: Optional[dict]) -> str:
+    """Serialize metadata deterministically for signature and persistence."""
+    return json.dumps(metadata or {}, sort_keys=True, separators=(",", ":"))
+
+
+def _optional_text(value: Optional[str]) -> str:
+    return value or ""
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
 def compute_signature(secret: str, *fields: str) -> str:
     """Compute HMAC-SHA256 over pipe-delimited fields.
 
@@ -146,9 +160,7 @@ def compute_signature(secret: str, *fields: str) -> str:
     cross-action signature reuse.
     """
     canonical = "|".join(fields)
-    return hmac.new(
-        secret.encode(), canonical.encode(), hashlib.sha256
-    ).hexdigest()
+    return hmac.new(secret.encode(), canonical.encode(), hashlib.sha256).hexdigest()
 
 
 def check_timestamp_freshness(client_ts: str) -> bool:
@@ -161,9 +173,76 @@ def check_timestamp_freshness(client_ts: str) -> bool:
     return abs(now - ts) <= _REPLAY_WINDOW
 
 
+def build_submit_signature_fields(
+    *,
+    sender: str,
+    channel: str,
+    timestamp: str,
+    subject: str,
+    body: str,
+    recipients: str,
+    priority: str,
+    parent_id: Optional[str],
+    metadata: Optional[dict],
+) -> tuple[str, ...]:
+    return (
+        "submit",
+        sender,
+        channel,
+        timestamp,
+        subject,
+        body,
+        recipients,
+        priority,
+        _optional_text(parent_id),
+        canonical_metadata_json(metadata),
+    )
+
+
+def build_approve_signature_fields(
+    *, agent_id: str, message_id: str, timestamp: str, note: str
+) -> tuple[str, ...]:
+    return ("approve", agent_id, message_id, timestamp, note)
+
+
+def build_reject_signature_fields(
+    *, agent_id: str, message_id: str, timestamp: str, reason: str
+) -> tuple[str, ...]:
+    return ("reject", agent_id, message_id, timestamp, reason)
+
+
+def build_ack_signature_fields(
+    *, agent_id: str, message_id: str, timestamp: str
+) -> tuple[str, ...]:
+    return ("ack", agent_id, message_id, timestamp)
+
+
+def build_broadcast_signature_fields(
+    *,
+    sender: str,
+    channel: str,
+    timestamp: str,
+    subject: str,
+    body: str,
+    priority: str,
+    auto_approve: bool,
+) -> tuple[str, ...]:
+    return (
+        "broadcast",
+        sender,
+        channel,
+        timestamp,
+        subject,
+        body,
+        priority,
+        _bool_text(auto_approve),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Agent registry
 # ---------------------------------------------------------------------------
+
 
 def verify_agent(conn: sqlite3.Connection, agent_id: str) -> bool:
     """Check that agent_id exists in the registry. No auto-registration."""
@@ -186,9 +265,24 @@ def is_orchestrator(conn: sqlite3.Connection, agent_id: str) -> bool:
     return "orchestrator" in row["roles"].split(",")
 
 
+def message_targets_agent(recipients: str, agent_id: str) -> bool:
+    if recipients == "*":
+        return True
+    return agent_id in [part.strip() for part in recipients.split(",") if part.strip()]
+
+
+def can_agent_ack_message(message: dict, agent_id: str) -> bool:
+    return bool(
+        message
+        and message.get("status") == "APPROVED"
+        and message_targets_agent(message.get("recipients", ""), agent_id)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Message lifecycle
 # ---------------------------------------------------------------------------
+
 
 def submit_message(
     conn: sqlite3.Connection,
@@ -228,7 +322,7 @@ def submit_message(
             decided_at,
             decided_by,
             parent_id,
-            json.dumps(metadata or {}),
+            canonical_metadata_json(metadata),
             signature,
             client_ts,
         ),
@@ -272,12 +366,14 @@ def list_messages(
             "OR recipients LIKE ? "
             "OR recipients LIKE ?)"
         )
-        params.extend([
-            recipient,            # exact single recipient
-            f"{recipient},%",     # first in list
-            f"%,{recipient},%",   # middle of list
-            f"%,{recipient}",     # last in list
-        ])
+        params.extend(
+            [
+                recipient,  # exact single recipient
+                f"{recipient},%",  # first in list
+                f"%,{recipient},%",  # middle of list
+                f"%,{recipient}",  # last in list
+            ]
+        )
     if since:
         clauses.append("submitted_at > ?")
         params.append(since)
@@ -334,21 +430,25 @@ def reject_message(
 def ack_message(conn: sqlite3.Connection, message_id: str, agent_id: str) -> Optional[dict]:
     """Record per-recipient acknowledgement via message_receipts."""
     msg = get_message(conn, message_id)
-    if not msg or msg["status"] != "APPROVED":
+    if not can_agent_ack_message(msg or {}, agent_id):
         return None
     now = _now()
     conn.execute(
         """INSERT INTO message_receipts (message_id, recipient, acked_at)
            VALUES (?, ?, ?)
-           ON CONFLICT(message_id, recipient) DO UPDATE SET acked_at = excluded.acked_at""",
+           ON CONFLICT(message_id, recipient) DO NOTHING""",
         (message_id, agent_id, now),
     )
     conn.commit()
     touch_agent(conn, agent_id)
+    receipt = conn.execute(
+        "SELECT acked_at FROM message_receipts WHERE message_id = ? AND recipient = ?",
+        (message_id, agent_id),
+    ).fetchone()
     result = get_message(conn, message_id)
-    if result:
+    if result and receipt:
         result["acked_by"] = agent_id
-        result["acked_at"] = now
+        result["acked_at"] = receipt["acked_at"]
     return result
 
 

--- a/src/delphi_broker/mcp_server.py
+++ b/src/delphi_broker/mcp_server.py
@@ -63,7 +63,7 @@ def delphi_submit(
     recipients can see them.
 
     Signature protocol:
-      canonical = "submit|sender|channel|timestamp|subject|body|recipients"
+      canonical = "submit|sender|channel|timestamp|subject|body|recipients|priority|parent_id|metadata_json"
       signature = HMAC-SHA256(secret, canonical)
 
     Args:
@@ -82,8 +82,20 @@ def delphi_submit(
         if not db.verify_agent(conn, sender):
             return {"error": f"Unknown agent '{sender}' — not in registry"}
         err = _verify_sig(
-            sender, signature, timestamp,
-            "submit", sender, channel, timestamp, subject, body, recipients,
+            sender,
+            signature,
+            timestamp,
+            *db.build_submit_signature_fields(
+                sender=sender,
+                channel=channel,
+                timestamp=timestamp,
+                subject=subject,
+                body=body,
+                recipients=recipients,
+                priority=priority,
+                parent_id=parent_id,
+                metadata=None,
+            ),
         )
         if err:
             return {"error": err}
@@ -127,7 +139,7 @@ def delphi_inbox(
         if not db.verify_agent(conn, agent_id):
             return {"error": f"Unknown agent '{agent_id}' — not in registry"}
         db.touch_agent(conn, agent_id)
-        exclude_acked = (status == "APPROVED")
+        exclude_acked = status == "APPROVED"
         messages = db.list_messages(
             conn,
             status=status or None,
@@ -183,11 +195,22 @@ def delphi_ack(
         if not db.verify_agent(conn, agent_id):
             return {"error": f"Unknown agent '{agent_id}' — not in registry"}
         err = _verify_sig(
-            agent_id, signature, timestamp,
-            "ack", agent_id, message_id, timestamp,
+            agent_id,
+            signature,
+            timestamp,
+            *db.build_ack_signature_fields(
+                agent_id=agent_id,
+                message_id=message_id,
+                timestamp=timestamp,
+            ),
         )
         if err:
             return {"error": err}
+        message = db.get_message(conn, message_id)
+        if not message or message["status"] != "APPROVED":
+            return {"error": "Message not found or not in APPROVED status"}
+        if not db.can_agent_ack_message(message, agent_id):
+            return {"error": f"Agent '{agent_id}' is not a recipient of message '{message_id}'"}
         result = db.ack_message(conn, message_id, agent_id)
         if not result:
             return {"error": "Message not found or not in APPROVED status"}
@@ -206,7 +229,7 @@ def delphi_approve(
 ) -> dict:
     """Approve a pending message. Orchestrator-only.
 
-    Signature: HMAC-SHA256(secret, "approve|agent_id|message_id|timestamp")
+    Signature: HMAC-SHA256(secret, "approve|agent_id|message_id|timestamp|note")
 
     Args:
         message_id: The message UUID to approve
@@ -217,11 +240,20 @@ def delphi_approve(
     """
     conn = _conn()
     try:
+        if not db.verify_agent(conn, agent_id):
+            return {"error": f"Unknown agent '{agent_id}' — not in registry"}
         if not db.is_orchestrator(conn, agent_id):
             return {"error": f"Agent '{agent_id}' is not an orchestrator"}
         err = _verify_sig(
-            agent_id, signature, timestamp,
-            "approve", agent_id, message_id, timestamp,
+            agent_id,
+            signature,
+            timestamp,
+            *db.build_approve_signature_fields(
+                agent_id=agent_id,
+                message_id=message_id,
+                timestamp=timestamp,
+                note=note,
+            ),
         )
         if err:
             return {"error": err}
@@ -243,7 +275,7 @@ def delphi_reject(
 ) -> dict:
     """Reject a pending message. Orchestrator-only.
 
-    Signature: HMAC-SHA256(secret, "reject|agent_id|message_id|timestamp")
+    Signature: HMAC-SHA256(secret, "reject|agent_id|message_id|timestamp|reason")
 
     Args:
         message_id: The message UUID to reject
@@ -254,11 +286,20 @@ def delphi_reject(
     """
     conn = _conn()
     try:
+        if not db.verify_agent(conn, agent_id):
+            return {"error": f"Unknown agent '{agent_id}' — not in registry"}
         if not db.is_orchestrator(conn, agent_id):
             return {"error": f"Agent '{agent_id}' is not an orchestrator"}
         err = _verify_sig(
-            agent_id, signature, timestamp,
-            "reject", agent_id, message_id, timestamp,
+            agent_id,
+            signature,
+            timestamp,
+            *db.build_reject_signature_fields(
+                agent_id=agent_id,
+                message_id=message_id,
+                timestamp=timestamp,
+                reason=reason,
+            ),
         )
         if err:
             return {"error": err}
@@ -283,7 +324,7 @@ def delphi_broadcast(
 ) -> dict:
     """Broadcast a message to all agents. Orchestrator-only.
 
-    Signature: HMAC-SHA256(secret, "broadcast|sender|channel|timestamp|subject|body")
+    Signature: HMAC-SHA256(secret, "broadcast|sender|channel|timestamp|subject|body|priority|auto_approve")
 
     Args:
         sender: Your agent ID (must have orchestrator role)
@@ -297,11 +338,23 @@ def delphi_broadcast(
     """
     conn = _conn()
     try:
+        if not db.verify_agent(conn, sender):
+            return {"error": f"Unknown agent '{sender}' — not in registry"}
         if not db.is_orchestrator(conn, sender):
             return {"error": f"Agent '{sender}' is not an orchestrator"}
         err = _verify_sig(
-            sender, signature, timestamp,
-            "broadcast", sender, channel, timestamp, subject, body,
+            sender,
+            signature,
+            timestamp,
+            *db.build_broadcast_signature_fields(
+                sender=sender,
+                channel=channel,
+                timestamp=timestamp,
+                subject=subject,
+                body=body,
+                priority=priority,
+                auto_approve=auto_approve,
+            ),
         )
         if err:
             return {"error": err}

--- a/src/delphi_broker/routes/api.py
+++ b/src/delphi_broker/routes/api.py
@@ -56,9 +56,20 @@ def submit_message(payload: MessageSubmit):
         if not db.verify_agent(conn, payload.sender):
             raise HTTPException(403, f"Unknown agent '{payload.sender}' — not in registry")
         _require_sig(
-            payload.sender, payload.signature, payload.timestamp,
-            "submit", payload.sender, payload.channel, payload.timestamp,
-            payload.subject, payload.body, payload.recipients,
+            payload.sender,
+            payload.signature,
+            payload.timestamp,
+            *db.build_submit_signature_fields(
+                sender=payload.sender,
+                channel=payload.channel,
+                timestamp=payload.timestamp,
+                subject=payload.subject,
+                body=payload.body,
+                recipients=payload.recipients,
+                priority=payload.priority,
+                parent_id=payload.parent_id,
+                metadata=payload.metadata,
+            ),
         )
         return db.submit_message(
             conn,
@@ -86,7 +97,7 @@ def inbox(
         if not db.verify_agent(conn, agent_id):
             raise HTTPException(403, f"Unknown agent '{agent_id}' — not in registry")
         db.touch_agent(conn, agent_id)
-        exclude_acked = (status == "APPROVED")
+        exclude_acked = status == "APPROVED"
         return db.list_messages(
             conn,
             status=status or None,
@@ -118,11 +129,20 @@ def pending(channel: str = "", limit: int = 50):
 def approve(message_id: str, payload: MessageDecision):
     conn = _conn()
     try:
+        if not db.verify_agent(conn, payload.agent_id):
+            raise HTTPException(403, f"Unknown agent '{payload.agent_id}' — not in registry")
         if not db.is_orchestrator(conn, payload.agent_id):
             raise HTTPException(403, f"Agent '{payload.agent_id}' is not an orchestrator")
         _require_sig(
-            payload.agent_id, payload.signature, payload.timestamp,
-            "approve", payload.agent_id, message_id, payload.timestamp,
+            payload.agent_id,
+            payload.signature,
+            payload.timestamp,
+            *db.build_approve_signature_fields(
+                agent_id=payload.agent_id,
+                message_id=message_id,
+                timestamp=payload.timestamp,
+                note=payload.note,
+            ),
         )
         result = db.approve_message(conn, message_id, payload.agent_id, payload.note)
         if not result:
@@ -136,11 +156,20 @@ def approve(message_id: str, payload: MessageDecision):
 def reject(message_id: str, payload: MessageReject):
     conn = _conn()
     try:
+        if not db.verify_agent(conn, payload.agent_id):
+            raise HTTPException(403, f"Unknown agent '{payload.agent_id}' — not in registry")
         if not db.is_orchestrator(conn, payload.agent_id):
             raise HTTPException(403, f"Agent '{payload.agent_id}' is not an orchestrator")
         _require_sig(
-            payload.agent_id, payload.signature, payload.timestamp,
-            "reject", payload.agent_id, message_id, payload.timestamp,
+            payload.agent_id,
+            payload.signature,
+            payload.timestamp,
+            *db.build_reject_signature_fields(
+                agent_id=payload.agent_id,
+                message_id=message_id,
+                timestamp=payload.timestamp,
+                reason=payload.reason,
+            ),
         )
         result = db.reject_message(conn, message_id, payload.agent_id, payload.reason)
         if not result:
@@ -157,9 +186,23 @@ def ack(message_id: str, payload: MessageAck):
         if not db.verify_agent(conn, payload.agent_id):
             raise HTTPException(403, f"Unknown agent '{payload.agent_id}' — not in registry")
         _require_sig(
-            payload.agent_id, payload.signature, payload.timestamp,
-            "ack", payload.agent_id, message_id, payload.timestamp,
+            payload.agent_id,
+            payload.signature,
+            payload.timestamp,
+            *db.build_ack_signature_fields(
+                agent_id=payload.agent_id,
+                message_id=message_id,
+                timestamp=payload.timestamp,
+            ),
         )
+        message = db.get_message(conn, message_id)
+        if not message or message["status"] != "APPROVED":
+            raise HTTPException(404, "Message not found or not APPROVED")
+        if not db.can_agent_ack_message(message, payload.agent_id):
+            raise HTTPException(
+                403,
+                f"Agent '{payload.agent_id}' is not a recipient of message '{message_id}'",
+            )
         result = db.ack_message(conn, message_id, payload.agent_id)
         if not result:
             raise HTTPException(404, "Message not found or not APPROVED")
@@ -172,12 +215,23 @@ def ack(message_id: str, payload: MessageAck):
 def broadcast(payload: BroadcastSubmit):
     conn = _conn()
     try:
+        if not db.verify_agent(conn, payload.sender):
+            raise HTTPException(403, f"Unknown agent '{payload.sender}' — not in registry")
         if not db.is_orchestrator(conn, payload.sender):
             raise HTTPException(403, f"Agent '{payload.sender}' is not an orchestrator")
         _require_sig(
-            payload.sender, payload.signature, payload.timestamp,
-            "broadcast", payload.sender, payload.channel, payload.timestamp,
-            payload.subject, payload.body,
+            payload.sender,
+            payload.signature,
+            payload.timestamp,
+            *db.build_broadcast_signature_fields(
+                sender=payload.sender,
+                channel=payload.channel,
+                timestamp=payload.timestamp,
+                subject=payload.subject,
+                body=payload.body,
+                priority=payload.priority,
+                auto_approve=payload.auto_approve,
+            ),
         )
         status = "APPROVED" if payload.auto_approve else "PENDING"
         return db.submit_message(

--- a/src/delphi_broker/routes/web.py
+++ b/src/delphi_broker/routes/web.py
@@ -3,8 +3,8 @@
 FILE:        web.py
 PATH:        C:/Projects/delphi-broker/src/delphi_broker/routes/web.py
 DESCRIPTION: Web UI routes for phone-friendly approval interface. The web UI
-             operates as the configured web-ui orchestrator identity — auth is
-             Tailnet-scoped, not application-scoped.
+             operates as the configured web-ui orchestrator identity and
+             requires explicit HTTP Basic auth.
 
 CHANGELOG:
 2026-03-31 17:30      Claude      [Harden] Fail-loud approve/reject, receipt
@@ -15,18 +15,37 @@ CHANGELOG:
 
 from __future__ import annotations
 
+import secrets
 from pathlib import Path
 
 import markdown
 import nh3
-from fastapi import APIRouter, Form, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.templating import Jinja2Templates
 
 from .. import database as db
-from ..config import DB_PATH, WEB_UI_AGENT_ID
+from ..config import DB_PATH, WEB_UI_AGENT_ID, WEB_UI_PASSWORD
 
-router = APIRouter(prefix="/web")
+_security = HTTPBasic()
+
+
+def _require_web_auth(
+    credentials: HTTPBasicCredentials = Depends(_security),
+) -> str:
+    username_ok = secrets.compare_digest(credentials.username, WEB_UI_AGENT_ID)
+    password_ok = secrets.compare_digest(credentials.password, WEB_UI_PASSWORD)
+    if not (username_ok and password_ok):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid web credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username
+
+
+router = APIRouter(prefix="/web", dependencies=[Depends(_require_web_auth)])
 
 _templates_dir = str(Path(__file__).resolve().parent.parent / "templates")
 templates = Jinja2Templates(directory=_templates_dir)
@@ -137,8 +156,11 @@ def message_detail(request: Request, message_id: str):
             reply["body_html"] = _render_body(reply["body"])
         receipts = db.get_receipts(conn, message_id)
         return _render(
-            request, "message_detail.html",
-            msg=msg, replies=replies, receipts=receipts,
+            request,
+            "message_detail.html",
+            msg=msg,
+            replies=replies,
+            receipts=receipts,
         )
     finally:
         conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@dataclass
+class BrokerStack:
+    config: object
+    database: object
+    client: TestClient
+
+    def sign(self, agent_id: str, *fields: str) -> str:
+        return self.database.compute_signature(self.config.AGENT_SECRETS[agent_id], *fields)
+
+
+def _reload_broker_modules() -> tuple[object, object, object]:
+    for name in sorted(sys.modules, reverse=True):
+        if name == "delphi_broker" or name.startswith("delphi_broker."):
+            sys.modules.pop(name, None)
+    fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+
+    class _FakeFastMCP:
+        def __init__(self, name: str):
+            self.name = name
+
+        def tool(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def streamable_http_app(self):
+            return FastAPI()
+
+    fastmcp_module.FastMCP = _FakeFastMCP
+    sys.modules["mcp"] = types.ModuleType("mcp")
+    sys.modules["mcp.server"] = types.ModuleType("mcp.server")
+    sys.modules["mcp.server.fastmcp"] = fastmcp_module
+    markdown_module = types.ModuleType("markdown")
+
+    class _FakeMarkdown:
+        def __init__(self, extensions=None):
+            self.extensions = extensions or []
+
+        def reset(self):
+            return None
+
+        def convert(self, text: str) -> str:
+            return text
+
+    markdown_module.Markdown = _FakeMarkdown
+    sys.modules["markdown"] = markdown_module
+    nh3_module = types.ModuleType("nh3")
+    nh3_module.clean = lambda html: html
+    sys.modules["nh3"] = nh3_module
+    python_multipart_module = types.ModuleType("python_multipart")
+    python_multipart_module.__version__ = "0.0.20"
+    sys.modules["python_multipart"] = python_multipart_module
+    multipart_module = types.ModuleType("multipart")
+    multipart_module.__version__ = "0.0.20"
+    sys.modules["multipart"] = multipart_module
+    multipart_submodule = types.ModuleType("multipart.multipart")
+    multipart_submodule.parse_options_header = lambda value: ("multipart/form-data", {})
+    sys.modules["multipart.multipart"] = multipart_submodule
+    config = importlib.import_module("delphi_broker.config")
+    database = importlib.import_module("delphi_broker.database")
+    main = importlib.import_module("delphi_broker.main")
+    return config, database, main
+
+
+@pytest.fixture
+def broker_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    agents_path = tmp_path / "agents.json"
+    agents_path.write_text(
+        json.dumps(
+            {
+                "agents": [
+                    {
+                        "agent_id": "worker-a",
+                        "host": "host-a",
+                        "roles": "worker",
+                        "secret": "a" * 64,
+                    },
+                    {
+                        "agent_id": "worker-b",
+                        "host": "host-b",
+                        "roles": "worker",
+                        "secret": "b" * 64,
+                    },
+                    {
+                        "agent_id": "orch",
+                        "host": "host-o",
+                        "roles": "worker,orchestrator",
+                        "secret": "c" * 64,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "broker.sqlite"
+    monkeypatch.setenv("DELPHI_AGENTS_PATH", str(agents_path))
+    monkeypatch.setenv("DELPHI_DB_PATH", str(db_path))
+    monkeypatch.setenv("DELPHI_WEB_UI_PASSWORD", "web-secret")
+    monkeypatch.setenv("DELPHI_WEB_UI_AGENT_ID", "web-ui")
+    monkeypatch.setenv("DELPHI_WEB_UI_ROLES", "orchestrator")
+
+    config, database, main = _reload_broker_modules()
+    with TestClient(main.app) as client:
+        yield BrokerStack(config=config, database=database, client=client)

--- a/tests/test_authority_contracts.py
+++ b/tests/test_authority_contracts.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import base64
+import sqlite3
+from datetime import datetime, timezone
+
+
+def _fresh_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _web_auth_headers(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def _create_message(
+    broker_stack,
+    *,
+    sender: str = "worker-a",
+    recipients: str = "worker-b",
+    status: str = "PENDING",
+) -> dict:
+    conn = broker_stack.database.get_connection(broker_stack.config.DB_PATH)
+    try:
+        return broker_stack.database.submit_message(
+            conn,
+            sender=sender,
+            channel="review",
+            subject="subject",
+            body="body",
+            recipients=recipients,
+            status=status,
+        )
+    finally:
+        conn.close()
+
+
+def test_submit_signature_covers_priority_parent_id_and_metadata(broker_stack):
+    payload = {
+        "sender": "worker-a",
+        "channel": "review",
+        "subject": "signed",
+        "body": "body",
+        "recipients": "worker-b",
+        "priority": "urgent",
+        "parent_id": "parent-1",
+        "metadata": {"z": 1, "a": 2},
+        "timestamp": _fresh_timestamp(),
+    }
+
+    payload["signature"] = broker_stack.sign(
+        "worker-a",
+        "submit",
+        payload["sender"],
+        payload["channel"],
+        payload["timestamp"],
+        payload["subject"],
+        payload["body"],
+        payload["recipients"],
+    )
+    bad_response = broker_stack.client.post("/api/v1/messages", json=payload)
+    assert bad_response.status_code == 403
+
+    payload["signature"] = broker_stack.sign(
+        "worker-a",
+        *broker_stack.database.build_submit_signature_fields(
+            sender=payload["sender"],
+            channel=payload["channel"],
+            timestamp=payload["timestamp"],
+            subject=payload["subject"],
+            body=payload["body"],
+            recipients=payload["recipients"],
+            priority=payload["priority"],
+            parent_id=payload["parent_id"],
+            metadata=payload["metadata"],
+        ),
+    )
+    good_response = broker_stack.client.post("/api/v1/messages", json=payload)
+    assert good_response.status_code == 200
+
+
+def test_approve_and_reject_signatures_cover_note_and_reason(broker_stack):
+    pending = _create_message(broker_stack)
+    approve_payload = {
+        "agent_id": "orch",
+        "note": "ship it",
+        "timestamp": _fresh_timestamp(),
+    }
+    approve_payload["signature"] = broker_stack.sign(
+        "orch",
+        "approve",
+        approve_payload["agent_id"],
+        pending["message_id"],
+        approve_payload["timestamp"],
+    )
+    bad_approve = broker_stack.client.post(
+        f"/api/v1/messages/{pending['message_id']}/approve", json=approve_payload
+    )
+    assert bad_approve.status_code == 403
+
+    approve_payload["signature"] = broker_stack.sign(
+        "orch",
+        *broker_stack.database.build_approve_signature_fields(
+            agent_id=approve_payload["agent_id"],
+            message_id=pending["message_id"],
+            timestamp=approve_payload["timestamp"],
+            note=approve_payload["note"],
+        ),
+    )
+    good_approve = broker_stack.client.post(
+        f"/api/v1/messages/{pending['message_id']}/approve", json=approve_payload
+    )
+    assert good_approve.status_code == 200
+
+    pending = _create_message(broker_stack)
+    reject_payload = {
+        "agent_id": "orch",
+        "reason": "needs work",
+        "timestamp": _fresh_timestamp(),
+    }
+    reject_payload["signature"] = broker_stack.sign(
+        "orch",
+        "reject",
+        reject_payload["agent_id"],
+        pending["message_id"],
+        reject_payload["timestamp"],
+    )
+    bad_reject = broker_stack.client.post(
+        f"/api/v1/messages/{pending['message_id']}/reject", json=reject_payload
+    )
+    assert bad_reject.status_code == 403
+
+    reject_payload["signature"] = broker_stack.sign(
+        "orch",
+        *broker_stack.database.build_reject_signature_fields(
+            agent_id=reject_payload["agent_id"],
+            message_id=pending["message_id"],
+            timestamp=reject_payload["timestamp"],
+            reason=reject_payload["reason"],
+        ),
+    )
+    good_reject = broker_stack.client.post(
+        f"/api/v1/messages/{pending['message_id']}/reject", json=reject_payload
+    )
+    assert good_reject.status_code == 200
+
+
+def test_broadcast_signature_covers_priority_and_auto_approve(broker_stack):
+    payload = {
+        "sender": "orch",
+        "channel": "ops",
+        "subject": "directive",
+        "body": "body",
+        "priority": "urgent",
+        "auto_approve": False,
+        "timestamp": _fresh_timestamp(),
+    }
+    payload["signature"] = broker_stack.sign(
+        "orch",
+        "broadcast",
+        payload["sender"],
+        payload["channel"],
+        payload["timestamp"],
+        payload["subject"],
+        payload["body"],
+    )
+    bad_response = broker_stack.client.post("/api/v1/messages/broadcast", json=payload)
+    assert bad_response.status_code == 403
+
+    payload["signature"] = broker_stack.sign(
+        "orch",
+        *broker_stack.database.build_broadcast_signature_fields(
+            sender=payload["sender"],
+            channel=payload["channel"],
+            timestamp=payload["timestamp"],
+            subject=payload["subject"],
+            body=payload["body"],
+            priority=payload["priority"],
+            auto_approve=payload["auto_approve"],
+        ),
+    )
+    good_response = broker_stack.client.post("/api/v1/messages/broadcast", json=payload)
+    assert good_response.status_code == 200
+
+
+def test_ack_requires_recipient_membership_and_is_idempotent(broker_stack):
+    approved = _create_message(broker_stack, recipients="worker-b", status="APPROVED")
+
+    wrong_ack = {
+        "agent_id": "worker-a",
+        "timestamp": _fresh_timestamp(),
+    }
+    wrong_ack["signature"] = broker_stack.sign(
+        "worker-a",
+        *broker_stack.database.build_ack_signature_fields(
+            agent_id=wrong_ack["agent_id"],
+            message_id=approved["message_id"],
+            timestamp=wrong_ack["timestamp"],
+        ),
+    )
+    wrong_response = broker_stack.client.post(
+        f"/api/v1/messages/{approved['message_id']}/ack", json=wrong_ack
+    )
+    assert wrong_response.status_code == 403
+
+    ack_payload = {
+        "agent_id": "worker-b",
+        "timestamp": _fresh_timestamp(),
+    }
+    ack_payload["signature"] = broker_stack.sign(
+        "worker-b",
+        *broker_stack.database.build_ack_signature_fields(
+            agent_id=ack_payload["agent_id"],
+            message_id=approved["message_id"],
+            timestamp=ack_payload["timestamp"],
+        ),
+    )
+    first_ack = broker_stack.client.post(
+        f"/api/v1/messages/{approved['message_id']}/ack", json=ack_payload
+    )
+    assert first_ack.status_code == 200
+    first_acked_at = first_ack.json()["acked_at"]
+
+    ack_payload["timestamp"] = _fresh_timestamp()
+    ack_payload["signature"] = broker_stack.sign(
+        "worker-b",
+        *broker_stack.database.build_ack_signature_fields(
+            agent_id=ack_payload["agent_id"],
+            message_id=approved["message_id"],
+            timestamp=ack_payload["timestamp"],
+        ),
+    )
+    second_ack = broker_stack.client.post(
+        f"/api/v1/messages/{approved['message_id']}/ack", json=ack_payload
+    )
+    assert second_ack.status_code == 200
+    assert second_ack.json()["acked_at"] == first_acked_at
+
+    receipts = broker_stack.client.get(f"/api/v1/messages/{approved['message_id']}/receipts")
+    assert receipts.status_code == 200
+    assert receipts.json() == [
+        {
+            "message_id": approved["message_id"],
+            "recipient": "worker-b",
+            "acked_at": first_acked_at,
+        }
+    ]
+
+
+def test_web_routes_require_basic_auth(broker_stack):
+    unauthorized = broker_stack.client.get("/web/")
+    assert unauthorized.status_code == 401
+
+    authorized = broker_stack.client.get(
+        "/web/",
+        headers=_web_auth_headers(broker_stack.config.WEB_UI_AGENT_ID, "web-secret"),
+    )
+    assert authorized.status_code == 200
+
+
+def test_existing_database_is_migrated_for_new_columns(broker_stack, tmp_path):
+    legacy_db = tmp_path / "legacy.sqlite"
+    conn = sqlite3.connect(legacy_db)
+    try:
+        conn.executescript("""
+            CREATE TABLE agents (
+                agent_id TEXT PRIMARY KEY,
+                host TEXT NOT NULL,
+                roles TEXT NOT NULL DEFAULT '',
+                first_seen TEXT NOT NULL,
+                last_seen TEXT NOT NULL,
+                metadata TEXT DEFAULT '{}'
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id TEXT NOT NULL UNIQUE,
+                channel TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                recipients TEXT NOT NULL DEFAULT '*',
+                subject TEXT NOT NULL DEFAULT '',
+                body TEXT NOT NULL,
+                priority TEXT NOT NULL DEFAULT 'normal',
+                status TEXT NOT NULL DEFAULT 'PENDING',
+                submitted_at TEXT NOT NULL,
+                decided_at TEXT,
+                decided_by TEXT,
+                decision_note TEXT DEFAULT '',
+                parent_id TEXT,
+                metadata TEXT DEFAULT '{}'
+            );
+            """)
+        conn.commit()
+    finally:
+        conn.close()
+
+    conn = broker_stack.database.get_connection(legacy_db)
+    try:
+        columns = {
+            row["name"]: row["type"]
+            for row in conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        assert "signature" in columns
+        assert "client_ts" in columns
+        receipts_table = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'message_receipts'"
+        ).fetchone()
+        assert receipts_table is not None
+    finally:
+        conn.close()


### PR DESCRIPTION
Root cause: the authority shell was incomplete. Authority-bearing fields could still change outside the signed contract, ACK was not recipient-bound, and the web approval surface had no explicit application-layer auth.

What changed:
- canonicalized and expanded signature coverage for submit/approve/reject/ack/broadcast
- restricted ACK to actual recipients and preserved idempotent first-receipt semantics
- added explicit Basic auth for the web UI approval surface
- added deterministic regression coverage for signature scope, ACK authorization, web auth, and schema migration

What did not change:
- SQLite remains the SSOT
- existing table meanings and lifecycle semantics remain intact
- web-ui remains the acting orchestrator identity
- no new runtime dependencies were introduced

Validation:
- python -m pytest -q --basetemp .pytest_tmp
- python -m ruff check src tests
- python -m black --check src tests
