### PR TITLE
Fix portable broker config and fail-loud placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@
 # Required
 # ---------------------------------------------------------------------------
 # Single shared secret that authorizes the operator (web UI + REST mutations).
+# Placeholder values starting with `GENERATE_WITH_` fail loud.
 # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
-DELPHI_OPERATOR_TOKEN=change-me-to-a-random-string
+DELPHI_OPERATOR_TOKEN=GENERATE_WITH_token_hex_32
 
 # ---------------------------------------------------------------------------
 # Network
@@ -27,9 +28,9 @@ DELPHI_ORIGINLESS_TRUSTED_INGRESS_CIDRS=
 # ---------------------------------------------------------------------------
 # Storage
 # ---------------------------------------------------------------------------
-# Container path (broker runs via docker; volume ./data → /app/data).
-# Override locally only if running broker outside docker.
-DELPHI_DB_PATH=/app/data/delphi.db
+# Relative paths are resolved from the repository root. In Docker, the
+# repository root is `/app`, so this still resolves to `/app/data/delphi.db`.
+DELPHI_DB_PATH=data/delphi.db
 
 # ---------------------------------------------------------------------------
 # Agent identity
@@ -37,7 +38,9 @@ DELPHI_DB_PATH=/app/data/delphi.db
 # Public agent manifest (committed canonical seed; structural fields only,
 # no inline secrets).
 DELPHI_AGENTS_PATH=config/agents.json
-OPERATOR_PERMANENTLY_HIDDEN_THREADS_PATH=config/operator_permanently_hidden_threads.json
+# Default to the committed empty seed so a fresh clone can start. Deployments
+# with local historical exclusions may point this at a gitignored local file.
+OPERATOR_PERMANENTLY_HIDDEN_THREADS_PATH=config/operator_permanently_hidden_threads.json.example
 
 # Registered participant identity bound to operator mark-read authority.
 # The request body cannot override this value.
@@ -105,9 +108,10 @@ DELPHI_MCP_SESSION_MANAGER_ENABLED=true
 # ---------------------------------------------------------------------------
 # Tailscale exposure (optional — for cross-host agent peer_send)
 # ---------------------------------------------------------------------------
-# Uncomment and set to this host's Tailscale IP to expose broker on the
-# Tailscale interface in addition to localhost. If set, also append the IP to
-# DELPHI_MCP_HOST_REGISTRY and DELPHI_MCP_ORIGIN_REGISTRY above (e.g.
+# Set to this host's Tailscale IP only when using
+# `docker compose -f docker-compose.yml -f docker-compose.tailscale.yml`.
+# Also append the IP to DELPHI_MCP_HOST_REGISTRY and DELPHI_MCP_ORIGIN_REGISTRY
+# above (e.g.
 #   DELPHI_MCP_HOST_REGISTRY=127.0.0.1:*,localhost:*,100.x.y.z:*
 #   DELPHI_MCP_ORIGIN_REGISTRY=...,http://100.x.y.z:8420
 # ).

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ venv/
 env/
 .env
 .coverage
-config/agents-secrets.json
 config/operator_permanently_hidden_threads.json
 *.db
 *.db-shm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,9 @@ Rule precedence:
 - Agent self-identification is mandatory on every MCP call.
 
 ### Configuration SSOT
-- `.env` — infrastructure config (operator token, host, port, db path, role overrides, web cookie security).
-- `config/agents.json` — public agent manifest (`agent_id`, `host`, `role`).
-- `config/agents-secrets.json` — gitignored sidecar for per-agent HMAC secrets in production.
-- `src/agent_broker/config.py` — single import point; loads from all of the above.
+- `.env` — infrastructure config, operator token, role overrides, web cookie security, and per-agent HMAC secrets.
+- `config/agents.json` — public agent manifest (`agent_id`, `host`, `role`, participant metadata).
+- `src/agent_broker/config.py` — single import point; loads from the above.
 
 ### API Surface
 - REST API at `/api/v1/session/*` — operator-facing session lifecycle.
@@ -130,7 +129,7 @@ The broker never advances past a pause without operator input. See `DESIGN.md` �
 - Refactor unrelated code for "cleanup"
 - Silence errors to make tests pass
 - Add heuristics, whitelists, or regex routing
-- Modify `.env`, `config/agents.json`, or `config/agents-secrets.json` without explicit instruction
+- Modify `.env` or `config/agents.json` without explicit instruction
 - Push to remote without explicit instruction
 - Reintroduce v1 surfaces (message lifecycle, approval routing, HTTP Basic auth, deprecated MCP tools)
 

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -145,9 +145,10 @@ env_file: ✅ or ❌
 mcp_config: ✅ or ❌
 ```
 
-**STOP HERE.** The operator must collect all secrets, populate
-`config/agents.json` (and optionally `config/agents-secrets.json`) on the broker
-host, and start the broker before you can verify.
+**STOP HERE.** The operator must collect all secrets, populate the matching
+`DELPHI_AGENT_SECRET_<NORMALIZED_AGENT_ID>` entries in the broker host `.env`,
+confirm `config/agents.json` contains the participant identity, and start the
+broker before you can verify.
 
 ---
 
@@ -281,7 +282,7 @@ cd ~/agent-broker  # or wherever the repo is cloned
 test -f .env || { echo "ERROR: .env not found"; exit 1; }
 grep -q '^DELPHI_OPERATOR_TOKEN=' .env || { echo "ERROR: DELPHI_OPERATOR_TOKEN not set in .env"; exit 1; }
 
-# Ensure config/agents.json (and agents-secrets.json if used) is populated
+# Ensure config/agents.json and .env DELPHI_AGENT_SECRET_* entries are populated
 test -f config/agents.json || { echo "ERROR: config/agents.json not found"; exit 1; }
 
 # Create data directory for SQLite persistence

--- a/DESIGN_v3.md
+++ b/DESIGN_v3.md
@@ -169,7 +169,7 @@ values fail loud; no code path invents runtime defaults.
 | `DELPHI_MCP_ORIGIN_REGISTRY` | fail loud at startup/import | HTTP Origin authority registry |
 | `DELPHI_DB_PATH` | fail loud at startup/import | SQLite SSOT path |
 | `DELPHI_AGENTS_PATH` | fail loud at startup/import | Public agent manifest path |
-| `DELPHI_AGENT_SECRETS_PATH` | fail loud at startup/import | Gitignored HMAC secret sidecar path |
+| `DELPHI_AGENT_SECRET_<NORMALIZED_AGENT_ID>` | fail loud at startup/import | Per-agent HMAC secret sourced from `.env` |
 | `DELPHI_WEB_SECURE` | fail loud at startup/import | Operator session cookie Secure flag |
 | `DELPHI_NUDGE_SWEEP_ENABLED` | fail loud at startup/import | Enables the v2 expired-nudge sweep background process |
 | `DELPHI_MCP_SESSION_MANAGER_ENABLED` | fail loud at startup/import | Enables FastMCP Streamable HTTP session management for `/mcp` |

--- a/README.md
+++ b/README.md
@@ -40,20 +40,21 @@ Infrastructure config lives in `.env` (copy from `.env.example`):
 
 ```
 # Required
-DELPHI_OPERATOR_TOKEN=change-me-to-a-random-string
+DELPHI_OPERATOR_TOKEN=GENERATE_WITH_token_hex_32
 
 # Network
-DELPHI_HOST=127.0.0.1
+DELPHI_HOST=0.0.0.0
 DELPHI_PORT=8420
 DELPHI_MCP_HOST_REGISTRY=127.0.0.1:*,localhost:*
 DELPHI_MCP_ORIGIN_REGISTRY=http://127.0.0.1:8420,http://localhost:8420
 
 # Storage
-DELPHI_DB_PATH=delphi.db
+DELPHI_DB_PATH=data/delphi.db
 
 # Agent identity
 DELPHI_AGENTS_PATH=config/agents.json
-DELPHI_AGENT_SECRETS_PATH=config/agents-secrets.json
+OPERATOR_PERMANENTLY_HIDDEN_THREADS_PATH=config/operator_permanently_hidden_threads.json.example
+OPERATOR_PARTICIPANT_ID=operator
 DELPHI_ARBITRATOR_AGENT_ID=flow-claude
 DELPHI_EXECUTOR_AGENT_ID=dev-codex-executor
 
@@ -65,38 +66,35 @@ DELPHI_MCP_SESSION_MANAGER_ENABLED=true
 
 | Variable | Required | Unset behavior | Notes |
 |---|---|---|---|
-| `DELPHI_OPERATOR_TOKEN` | yes | fail loud on protected web/API use | Generate with `python -c "import secrets; print(secrets.token_hex(32))"` |
+| `DELPHI_OPERATOR_TOKEN` | yes | fail loud on protected web/API use | Generate with `python -c "import secrets; print(secrets.token_hex(32))"`; placeholders are rejected |
 | `DELPHI_HOST` | yes | fail loud at startup/import | Localhost mode uses `127.0.0.1` |
 | `DELPHI_PORT` | yes | fail loud at startup/import | |
 | `DELPHI_MCP_HOST_REGISTRY` | yes | fail loud at startup/import | Deployment host-header registry for MCP transport security |
 | `DELPHI_MCP_ORIGIN_REGISTRY` | yes | fail loud at startup/import | Deployment Origin registry for HTTP ingress |
 | `DELPHI_DB_PATH` | yes | fail loud at startup/import | Resolved relative to project root unless absolute |
 | `DELPHI_AGENTS_PATH` | yes | fail loud at startup/import | Public agent manifest (committed) |
-| `DELPHI_AGENT_SECRETS_PATH` | yes | fail loud at startup/import | Sidecar path for production secrets |
+| `OPERATOR_PERMANENTLY_HIDDEN_THREADS_PATH` | yes | fail loud at startup/import | Relative path to operator-managed hidden-thread config; the committed example is an empty seed |
+| `OPERATOR_PARTICIPANT_ID` | yes | fail loud at startup/import | Must exist in `config/agents.json` |
 | `DELPHI_ARBITRATOR_AGENT_ID` | yes | fail loud at startup/import | Must exist with `role='arbitrator'` |
 | `DELPHI_EXECUTOR_AGENT_ID` | yes | fail loud at startup/import | Must exist with `role='executor'` (cannot also be a worker — see `DESIGN.md` §2) |
 | `DELPHI_WEB_SECURE` | yes | fail loud at startup/import | `true`/`1`/`yes` flags the operator session cookie `Secure` |
 | `DELPHI_NUDGE_SWEEP_ENABLED` | yes | fail loud at startup/import | Enables the background expired-nudge sweep |
 | `DELPHI_MCP_SESSION_MANAGER_ENABLED` | yes | fail loud at startup/import | Enables the FastMCP stream session manager for HTTP MCP transport |
 
-Agent registry lives in `config/agents.json` (copy from example):
-
-```bash
-cp config/agents.json.example config/agents.json
-```
-
-Each agent entry declares `agent_id`, `host`, exactly one `role` from `worker | arbitrator | executor`, and an explicit `collaboration_governed` boolean. Per-agent HMAC secrets can be inlined (development) or kept in `config/agents-secrets.json` (production). Participants that must use operator-mediated collaboration set `collaboration_governed: true`; direct peer sends involving those participants are rejected and must use the collaboration lifecycle.
+Agent registry lives in committed `config/agents.json`. Each agent entry declares `agent_id`, `host`, exactly one `role` from `worker | arbitrator | executor | operator`, participant metadata, and an explicit `collaboration_governed` boolean. Per-agent HMAC secrets live in `.env` as `DELPHI_AGENT_SECRET_<NORMALIZED_AGENT_ID>`. Participants that must use operator-mediated collaboration set `collaboration_governed: true`; direct peer sends involving those participants are rejected and must use the collaboration lifecycle.
 
 ## Running
 
 ### Docker (production)
 
 ```bash
-cp .env.example .env  # fill in DELPHI_OPERATOR_TOKEN
+cp .env.example .env  # generate DELPHI_OPERATOR_TOKEN and DELPHI_AGENT_SECRET_* values
 docker compose -p agent-broker up -d --build
 ```
 
 > The `-p agent-broker` flag isolates this stack from other compose projects on the same host.
+> To expose the broker on a private-network interface, set `BROKER_TAILSCALE_IP`
+> in `.env` and run with `-f docker-compose.yml -f docker-compose.tailscale.yml`.
 
 Data persists in `./data/` (SQLite DB). Agent registry is mounted read-only from `./config/`.
 
@@ -104,7 +102,7 @@ Data persists in `./data/` (SQLite DB). Agent registry is mounted read-only from
 
 ```bash
 pip install -r requirements.txt
-cp .env.example .env  # fill in DELPHI_OPERATOR_TOKEN
+cp .env.example .env  # generate DELPHI_OPERATOR_TOKEN and DELPHI_AGENT_SECRET_* values
 PYTHONPATH=src python -m agent_broker.main
 ```
 
@@ -156,9 +154,10 @@ agent-broker/
   DESIGN.md             # Authoritative architecture contract (v2)
   Dockerfile            # Container image
   docker-compose.yml    # Production deployment
+  docker-compose.tailscale.yml # Optional private-network port binding
   config/
-    agents.json.example
-    agents-secrets.json.example
+    agents.json
+    operator_permanently_hidden_threads.json.example
   src/agent_broker/
     config.py           # Configuration loader (single import point)
     database.py         # SQLite layer + signature helpers

--- a/docker-compose.tailscale.yml
+++ b/docker-compose.tailscale.yml
@@ -1,0 +1,5 @@
+services:
+  broker:
+    ports:
+      # Cross-host private-network peers reach broker via the configured interface.
+      - "${BROKER_TAILSCALE_IP}:${DELPHI_PORT}:8420"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     ports:
       # Pi-local agents (pi-claude, pi-codex) reach broker via localhost.
       - "127.0.0.1:${DELPHI_PORT}:8420"
-      # Cross-host Tailscale peers (bsflow-claude, etc.) reach broker via Pi Tailscale IP.
-      - "${BROKER_TAILSCALE_IP}:${DELPHI_PORT}:8420"
     volumes:
       - ./data:/app/data
       - ./config:/app/config:ro

--- a/src/agent_broker/config.py
+++ b/src/agent_broker/config.py
@@ -178,6 +178,14 @@ def require_operator_token() -> str:
             '`python -c "import secrets; print(secrets.token_hex(32))"`'
             " and put it in .env or the process environment."
         )
+    if (
+        OPERATOR_TOKEN.startswith("GENERATE_WITH_")
+        or OPERATOR_TOKEN == "change-me-to-a-random-string"
+    ):
+        raise RuntimeError(
+            "DELPHI_OPERATOR_TOKEN is still a placeholder. Replace it with a "
+            'fresh secret: python -c "import secrets; print(secrets.token_hex(32))"'
+        )
     return OPERATOR_TOKEN
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,17 +106,27 @@ def test_phase_3_config_registers_pi_codex():
         "is_probe": False,
         "collaboration_governed": False,
     }.items() <= pi_codex[0].items()
-    assert "config/agents-secrets.json" in (root / ".gitignore").read_text(encoding="utf-8")
+    assert "config/agents-secrets.json" not in (root / ".env.example").read_text(
+        encoding="utf-8"
+    )
+    assert "config/agents-secrets.json" not in (root / ".gitignore").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_operator_hidden_threads_config_is_gitignored_with_example():
     root = Path(__file__).resolve().parents[1]
     gitignore = (root / ".gitignore").read_text()
+    env_example = (root / ".env.example").read_text()
     example = json.loads(
         (root / "config" / "operator_permanently_hidden_threads.json.example").read_text()
     )
 
     assert "config/operator_permanently_hidden_threads.json" in gitignore
+    assert (
+        "OPERATOR_PERMANENTLY_HIDDEN_THREADS_PATH="
+        "config/operator_permanently_hidden_threads.json.example"
+    ) in env_example
     assert example["thread_ids"] == []
     assert example["_meta"]["changelog"]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,3 +174,58 @@ def test_config_rejects_missing_collaboration_governed_flag(tmp_path, monkeypatc
 
     with pytest.raises(ValueError, match="collaboration_governed"):
         importlib.import_module("agent_broker.config")
+
+
+def test_config_rejects_placeholder_operator_token(tmp_path, monkeypatch):
+    agents_path = tmp_path / "agents.json"
+    agents_path.write_text(
+        json.dumps(
+            {
+                "agents": [
+                    {
+                        "agent_id": "operator",
+                        "host": "pi",
+                        "role": "operator",
+                        "participant_type": "operator",
+                        "transport_type": "http",
+                        "collaboration_governed": False,
+                        "is_probe": False,
+                        "secret": "a" * 64,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    permanently_hidden_threads_path = tmp_path / "operator_permanently_hidden_threads.json"
+    permanently_hidden_threads_path.write_text(
+        json.dumps({"_meta": {"changelog": []}, "thread_ids": []}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DELPHI_AGENTS_PATH", str(agents_path))
+    monkeypatch.setenv(
+        "OPERATOR_PERMANENTLY_HIDDEN_THREADS_PATH", str(permanently_hidden_threads_path)
+    )
+    monkeypatch.setenv("OPERATOR_PARTICIPANT_ID", "operator")
+    monkeypatch.setenv("DELPHI_DB_PATH", str(tmp_path / "broker.sqlite"))
+    monkeypatch.setenv("DELPHI_HOST", "127.0.0.1")
+    monkeypatch.setenv("DELPHI_PORT", "8420")
+    monkeypatch.setenv("DELPHI_MCP_HOST_REGISTRY", "127.0.0.1:*,localhost:*")
+    monkeypatch.setenv(
+        "DELPHI_MCP_ORIGIN_REGISTRY",
+        "http://127.0.0.1:8420,http://localhost:8420",
+    )
+    monkeypatch.setenv("DELPHI_ORIGINLESS_TRUSTED_INGRESS_CIDRS", "")
+    monkeypatch.setenv("DELPHI_WEB_SECURE", "false")
+    monkeypatch.setenv("DELPHI_NUDGE_SWEEP_ENABLED", "false")
+    monkeypatch.setenv("DELPHI_MCP_SESSION_MANAGER_ENABLED", "false")
+    monkeypatch.setenv("DELPHI_ARBITRATOR_AGENT_ID", "operator")
+    monkeypatch.setenv("DELPHI_EXECUTOR_AGENT_ID", "operator")
+    monkeypatch.setenv("DELPHI_OPERATOR_TOKEN", "GENERATE_WITH_token_hex_32")
+    for name in sorted(sys.modules, reverse=True):
+        if name == "agent_broker" or name.startswith("agent_broker."):
+            sys.modules.pop(name, None)
+
+    config = importlib.import_module("agent_broker.config")
+    with pytest.raises(RuntimeError, match="placeholder"):
+        config.require_operator_token()


### PR DESCRIPTION
## Summary
- make .env.example use repo-relative DB and committed hidden-thread seed paths for cross-host/cross-OS setup
- split optional Tailscale port binding into docker-compose.tailscale.yml so base compose does not require BROKER_TAILSCALE_IP
- reject placeholder operator tokens and remove stale sidecar-secret setup references from active docs/tests

## Validation
- git diff --check
- config import probe with .env.example values replaced by generated dummy secrets
- operator-token placeholder rejection probe
- docker compose config with generated dummy .env
- docker compose -f docker-compose.yml -f docker-compose.tailscale.yml config with generated dummy .env and BROKER_TAILSCALE_IP
- temporary venv: python -m ruff check .
- temporary venv: python -m pytest -q tests/test_config.py tests/test_api.py -p no:cacheprovider --basetemp .tmp/pytest-portable-config

No runtime state or production env files changed. Pre-existing local prod-*.env files remain untracked.